### PR TITLE
removed "assigned to" section since its redundant

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-todo.yml
+++ b/.github/ISSUE_TEMPLATE/2-todo.yml
@@ -24,12 +24,3 @@ body:
         - [ ] Item 4
     validations:
       required: true
-
-  - type: textarea
-    id: assignee
-    attributes:
-      label: Assigned to...
-      description: "@mention a person or team"
-      placeholder: "@team (@user - @user)"
-    validations:
-      required: false


### PR DESCRIPTION
## Describe your changes...
Removed assigned section in the todo template because its redundant.

This one didn't break anything else.